### PR TITLE
a simpler method for citing RFCs; add a tech report

### DIFF
--- a/ref.bib
+++ b/ref.bib
@@ -1,14 +1,19 @@
-@misc{rfc7089,
-  author       = {Herbert {Van de Sompel} and
-                  Michael L. Nelson and
-                  Robert Sanderson},
-  title        = {{HTTP Framework for Time-Based Access to Resource States -- Memento}},
-  series       = {Request for Comments},
-  number       = {7089},
-  howpublished = {RFC 7089},
-  publisher    = {IETF},
-  organization = {Internet Engineering Task Force},
-  year         = {2013},
-  month        = {dec},
-  url          = {\url{http://tools.ietf.org/html/rfc7089}},
+@misc{memento:rfc,
+        title = {{HTTP framework for time-based access to resource states -- Memento, Internet RFC 7089}},
+        author = {Herbert {Van de Sompel} and Michael L. Nelson and Robert Sanderson},
+        year = {2013},
+        howpublished ={http://tools.ietf.org/html/rfc7089},
+}
+@misc{rfc2616,
+        author = {R. Fielding and J. Gettys and J. Mogul and H. Frystyk and L. Masinter and P. Leach and T. Berners-Lee},
+        title = {{Hypertex Transfer Protocol -- HTTP/1.1, Internet RFC-2616}},
+        year = {1999},
+}
+@techreport{nelson:memento:tr,
+        title = {{Memento: Time Travel for the Web}},
+        author = {Herbert {Van de Sompel} and Michael L. Nelson and
+        Robert Sanderson and Lyudmila L. Balakireva and Scott Ainsworth and
+        Harihar Shankar},
+        year = {2009},
+        number = {arXiv:0911.1112},
 }


### PR DESCRIPTION
this is a simpler way to cite RFCs; it almost always does the right thing.  
this is also my preferred way to cite arXiv tech reports.