### PR TITLE
Improve compilation speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ RVDIR=./revisions/
 all: clean build clear
 
 build:
-	$(LATEX) -shell-escape $(MAIN).tex
+	$(LATEX) -shell-escape -draftmode $(MAIN).tex
 	$(BIBTEX) $(MAIN)
-	$(LATEX) -shell-escape $(MAIN).tex
+	$(LATEX) -shell-escape -draftmode $(MAIN).tex
 	$(LATEX) -shell-escape $(MAIN).tex
 
 clean:


### PR DESCRIPTION
The first two passes of pdflatex can be done in draftmode to save
compilation time without sacrificing quality