### PR TITLE
handle pdflatex error better

### DIFF
--- a/custommacros.sty
+++ b/custommacros.sty
@@ -11,6 +11,7 @@
 \makeatletter
 \def\app@exe{\immediate\write18}
 \def\inputAllFiles#1{%
+  \app@exe{rm -f #1/\jobname.tmp}
   \app@exe{ls #1/*.tex | xargs cat >> #1/\jobname.tmp}%
   \InputIfFileExists{#1/\jobname.tmp}{}
   \AtEndDocument{\app@exe{rm -f #1/\jobname.tmp}}}

--- a/custommacros.sty
+++ b/custommacros.sty
@@ -11,7 +11,6 @@
 \makeatletter
 \def\app@exe{\immediate\write18}
 \def\inputAllFiles#1{%
-  \app@exe{rm -f #1/\jobname.tmp}
   \app@exe{ls #1/*.tex | xargs cat >> #1/\jobname.tmp}%
   \InputIfFileExists{#1/\jobname.tmp}{}
   \AtEndDocument{\app@exe{rm -f #1/\jobname.tmp}}}

--- a/custommacros.sty
+++ b/custommacros.sty
@@ -11,8 +11,7 @@
 \makeatletter
 \def\app@exe{\immediate\write18}
 \def\inputAllFiles#1{%
-  \app@exe{rm -f #1/\jobname.tmp}
-  \app@exe{ls #1/*.tex | xargs cat >> #1/\jobname.tmp}%
+  \app@exe{cat #1/*.tex > #1/\jobname.tmp}%
   \InputIfFileExists{#1/\jobname.tmp}{}
   \AtEndDocument{\app@exe{rm -f #1/\jobname.tmp}}}
 \makeatother


### PR DESCRIPTION
Correct me if I am wrong but I believe if you use the makefile and fail to compile the document ( I know this cannot happen everybody writes correct latex code at his/her first try :D ) then due to the fact that:
* ['inputAllFiles'](https://github.com/oduwsdl/wsdlthesis/blob/ea0ec87f385ab835240679fe81e252cdf6a874ef/custommacros.sty#L13) appends contents without checking for the existence of the temp file 
* `  \AtEndDocument{\app@exe{rm -f #1/\jobname.tmp}}}` will not be executed.
new contents will keep concatenating upon the original flawed file. So the error remains forever!

TL;DR
executes `\app@exe{rm -f #1/\jobname.tmp}` in `\inputAllFiles` before everything else to ensure a clean initial state.