### PR TITLE
Fix page numbers for multi-page LoT, LoF, and Refs in ToC

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -15,11 +15,13 @@
 
 \inputAllFiles{chapters}
 
-\bibliographystyle{ieeetr}
-\bibliography{ref}
+\cleardoublepage
+\phantomsection
 
 \addtocontents{toc}{\vspace*{12pt}}
 \addcontentsline{toc}{chapter}{REFERENCES}
+\bibliographystyle{ieeetr}
+\bibliography{ref}
 
 \appendix
 

--- a/wsdlthesis.cls
+++ b/wsdlthesis.cls
@@ -223,27 +223,22 @@
         \chapter*{#1}}
 
 \def\afterpreface{\cleardoublepage
+        \phantomsection
         \def\baselinestretch{1}\@normalsize
         \tableofcontents
         \cleardoublepage
+        \phantomsection
         \iftablespage
-                {\addvspace{10pt}
-                \let\saveaddvspace=\addvspace
-                \def\addvspace##1{}
-                \listoftables
-                \let\addvspace=\saveaddvspace
                 \addcontentsline{toc}{chapter}{\uppercase{List of Tables}}
-                \let\addvspace=\saveaddvspace}
+                \listoftables
                 \cleardoublepage
+                \phantomsection
         \fi
         \iffigurespage
-                {\addvspace{10pt}
-                \let\saveaddvspace=\addvspace
-                \def\addvspace##1{}
-                \listoffigures
                 \addcontentsline{toc}{chapter}{\uppercase{List of Figures}}
-                \let\addvspace=\saveaddvspace}
+                \listoffigures
                 \cleardoublepage
+                \phantomsection
         \fi
         \def\baselinestretch{1.3}\@normalsize
         \pagenumbering{arabic}


### PR DESCRIPTION
When list of tables, list of figures, and references span over multiple pages, their last page numbers are referenced in the table of contents This PR fixes this issue and also takes care of proper hyperlinking in ToC.