### PR TITLE
Prevent overflow of URLs in references

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -15,6 +15,9 @@
 
 \inputAllFiles{chapters}
 
+% Prevent overflow of URLs in references
+\emergencystretch 2em
+
 \cleardoublepage
 \phantomsection
 


### PR DESCRIPTION
Stretched spacing in URLs might look awkward, but better than letting them overflow into margins.